### PR TITLE
Fix column assignment syntax in sqlfind.m

### DIFF
--- a/inst/@octave_sqlite/sqlfind.m
+++ b/inst/@octave_sqlite/sqlfind.m
@@ -121,7 +121,7 @@ function data = sqlfind (db, pattern, varargin)
   
     cols = {};
     for j=1:length(ti)
-      cols{end+1} = ti(j);
+      cols(end+1) = ti(j);
     endfor
     columns{end+1} = cols;
   endfor


### PR DESCRIPTION
This PR solves issue #9, by avoiding returning nested cells in the `Coloumns` variable.  Instead, it returns a cellstr array for each table.